### PR TITLE
97/posts filterable through query parameters

### DIFF
--- a/backend/api.yaml
+++ b/backend/api.yaml
@@ -378,6 +378,27 @@ paths:
                 id:
                   type: integer
         description: ''
+      parameters:
+        - schema:
+            type: integer
+          in: query
+          name: post_id
+          description: 'returns a single post that matches this ID, if any'
+        - schema:
+            type: integer
+          in: query
+          name: tag_id
+          description: returns posts that have a tag with this ID
+        - schema:
+            type: integer
+          in: query
+          name: category_id
+          description: returns posts that have the category with this ID
+        - schema:
+            type: string
+          in: query
+          name: keyword
+          description: 'returns posts that contain this keyword in the title, category, any of its tags, or the body text (case-insensitive)'
   '/tags/{tag_id}/update':
     parameters:
       - schema:

--- a/backend/drf_project/api/tests/test_post_view.py
+++ b/backend/drf_project/api/tests/test_post_view.py
@@ -9,6 +9,8 @@ from django.urls import reverse
 from .. import models
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.http import urlencode
+import json
 import os
 from time import time
 
@@ -160,6 +162,10 @@ class PostViewTestCase(TestCase):
             content='<p>Fish sticks are a delicious food.</p>',
             category=category_1)
         self.test_post_1.tags.set([tag_1])
-        res = self.client.get(reverse('view posts'))
-        # must make assertions and actually filter the posts
-        # also must add post id filter to the test
+        url = reverse('view posts')
+        query_kwargs = {'post_id': self.test_post_1.id, 'tag_id': tag_1.id,
+            'category_id': category_1.id, 'keyword': 'Fish'}
+        res = self.client.get(f'{url}?{urlencode(query_kwargs)}')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.json()[0]['id'], self.test_post_1.id)
+        self.assertEqual(len(res.json()), 1)

--- a/backend/drf_project/api/views.py
+++ b/backend/drf_project/api/views.py
@@ -39,11 +39,13 @@ class PostViewSet(viewsets.ModelViewSet):
         in the title, the category, any of its tags, or the
         body text.
         """
-        # TODO: add post_id filtering
         queryset = models.Post.objects.all()
+        post_id = self.request.query_params.get('post_id', None)
         tag_id = self.request.query_params.get('tag_id', None)
         category_id = self.request.query_params.get('category_id', None)
         keyword = self.request.query_params.get('keyword', None)
+        if post_id is not None:
+            queryset = queryset.filter(id=post_id)
         if tag_id is not None:
             queryset = queryset.filter(tags__id=tag_id)
         if category_id is not None:


### PR DESCRIPTION
## Checklist
- [x] Ran linter and cleared all problems
- [x] Cleared all console statements and console errors
- [x] Deleted all extraneous comments, commented-out code, etc. 

## Describe what you changed
- defined a get_queryset() function for posts in views.py, allowing for filtering of posts through the query parameters 'post_id', 'tag_id', 'category_id' and 'keyword'
- wrote a test for query parameter filtering in test_post_view.py
- added the query parameters with brief descriptions to api.yaml

## (Optional) Note down anything else related to this issue & pull request. 

